### PR TITLE
Manual image fusion UI

### DIFF
--- a/res/stylesheet-win-linux.qss
+++ b/res/stylesheet-win-linux.qss
@@ -547,3 +547,22 @@ QSlider::add-page:vertical {
     margin-left:5px;
     margin-right:5px;
 }
+
+QRadioButton#FusionModeRadio {
+    font-family: "Segoe UI", "Roboto", "Helvetica Neue", sans-serif;
+    font-size: 16px;
+    color: black;
+    font-weight: semi-bold;
+}
+
+QLabel#FusionModeLabel {
+    font-family: "Segoe UI", "Roboto", "Helvetica Neue", sans-serif;
+    font-size: 16px;
+    color: black;
+    font-weight: bold;
+}
+
+QRadioButton#FusionModeRadio:disabled, QLabel#FusionModeLabel:disabled {
+    color: #a0a0a0;
+    opacity: 0.35;
+}

--- a/src/Controller/TopLevelController.py
+++ b/src/Controller/TopLevelController.py
@@ -116,6 +116,21 @@ class Controller:
         # time), close all the other open windows.
         progress_window.update_progress(("Loading complete!", 100))
         progress_window.close()
+
+        # If this is a manual fusion, set the images and update the fusion tab
+        if hasattr(progress_window, "images"):
+            images = progress_window.images
+            if hasattr(self.main_window, "fixed_image_sitk"):
+                self.main_window.fixed_image_sitk = images.get("fixed_image")
+            else:
+                setattr(self.main_window, "fixed_image_sitk", images.get("fixed_image"))
+            if hasattr(self.main_window, "moving_image_sitk"):
+                self.main_window.moving_image_sitk = images.get("moving_image")
+            else:
+                setattr(self.main_window, "moving_image_sitk", images.get("moving_image"))
+            if hasattr(self.main_window, "create_image_fusion_tab"):
+                self.main_window.create_image_fusion_tab()
+
         self.main_window.show()
         self.open_patient_window.close()
         self.image_fusion_window.close()

--- a/src/View/ImageFusion/ImageFusionAxialView.py
+++ b/src/View/ImageFusion/ImageFusionAxialView.py
@@ -168,18 +168,27 @@ class ImageFusionAxialView(DicomView):
                 stylesheet = "QLabel { color : white; }"
             self.format_metadata_labels(stylesheet)
 
-    def image_display(self):
+    def image_display(self, overlay_image=None):
         """
         Update the image to be displayed on the DICOM View.
+        If overlay_image is provided, use it as the overlay for this view.
         """
-        pixmaps = self.patient_dict_container.get("color_"+self.slice_view)
-        slider_id = self.slider.value()
-        image = pixmaps[slider_id]
+        if overlay_image is not None:
+            image = overlay_image
+        elif hasattr(self, "overlay_images"):
+            slider_id = self.slider.value()
+            image = self.overlay_images[slider_id]
+        else:
+            pixmaps = self.patient_dict_container.get("color_"+self.slice_view)
+            if pixmaps is None:
+                return  # Prevent NoneType subscriptable error
+            slider_id = self.slider.value()
+            image = pixmaps[slider_id]
 
         label = QtWidgets.QGraphicsPixmapItem(image)
         self.scene = GraphicsScene(
             label, self.horizontal_view, self.vertical_view)
-
+        
     def update_view(self, zoom_change=False):
         """
         Update the view of the DICOM Image.

--- a/src/View/ImageFusion/ImageFusionCoronalView.py
+++ b/src/View/ImageFusion/ImageFusionCoronalView.py
@@ -13,13 +13,22 @@ class ImageFusionCoronalView(DicomView):
                                                      cut_line_color)
         self.update_view()
 
-    def image_display(self):
+    def image_display(self, overlay_image=None):
         """
         Update the image to be displayed on the DICOM View.
+        If overlay_image is provided, use it as the overlay for this view.
         """
-        pixmaps = self.patient_dict_container.get("color_"+self.slice_view)
-        slider_id = self.slider.value()
-        image = pixmaps[slider_id]
+        if overlay_image is not None:
+            image = overlay_image
+        elif hasattr(self, "overlay_images"):
+            slider_id = self.slider.value()
+            image = self.overlay_images[slider_id]
+        else:
+            pixmaps = self.patient_dict_container.get("color_"+self.slice_view)
+            if pixmaps is None:
+                return  # Prevent NoneType subscriptable error
+            slider_id = self.slider.value()
+            image = pixmaps[slider_id]
 
         label = QtWidgets.QGraphicsPixmapItem(image)
         self.scene = GraphicsScene(

--- a/src/View/ImageFusion/ImageFusionSagittalView.py
+++ b/src/View/ImageFusion/ImageFusionSagittalView.py
@@ -19,13 +19,22 @@ class ImageFusionSagittalView(DicomView):
 
         self.update_view()
 
-    def image_display(self):
+    def image_display(self, overlay_image=None):
         """
         Update the image to be displayed on the DICOM View.
+        If overlay_image is provided, use it as the overlay for this view.
         """
-        pixmaps = self.patient_dict_container.get("color_"+self.slice_view)
-        slider_id = self.slider.value()
-        image = pixmaps[slider_id]
+        if overlay_image is not None:
+            image = overlay_image
+        elif hasattr(self, "overlay_images"):
+            slider_id = self.slider.value()
+            image = self.overlay_images[slider_id]
+        else:
+            pixmaps = self.patient_dict_container.get("color_"+self.slice_view)
+            if pixmaps is None:
+                return  # Prevent NoneType subscriptable error
+            slider_id = self.slider.value()
+            image = pixmaps[slider_id]
 
         label = QtWidgets.QGraphicsPixmapItem(image)
         self.scene = GraphicsScene(

--- a/src/View/ImageFusion/ImageFusionWindow.py
+++ b/src/View/ImageFusion/ImageFusionWindow.py
@@ -41,24 +41,7 @@ class UIImageFusionWindow(object):
         self.open_patient_window_instance_vertical_box = QVBoxLayout()
         self.open_patient_window_instance_vertical_box.setObjectName(
             "OpenPatientWindowInstanceVerticalBox")
-
-        # Fusion Mode Switch Selector
-        self.fusion_mode_layout = QHBoxLayout()
-        self.fusion_mode_label = QLabel("Fusion Mode:")
-        self.fusion_mode_layout.addWidget(self.fusion_mode_label)
-
-        self.fusion_mode_group = QButtonGroup()
-        self.manual_radio = QRadioButton("Manual Fusion")
-        self.auto_radio = QRadioButton("Auto Fusion")
-        self.fusion_mode_group.addButton(self.manual_radio)
-        self.fusion_mode_group.addButton(self.auto_radio)
-        self.manual_radio.setChecked(True)
-        self.manual_radio.setEnabled(False)
-        self.auto_radio.setEnabled(False)
-        self.fusion_mode_layout.addWidget(self.manual_radio)
-        self.fusion_mode_layout.addWidget(self.auto_radio)
-        self.open_patient_window_instance_vertical_box.addLayout(self.fusion_mode_layout)
-
+        
         # Create a label to prompt the user to enter the path to the
         # directory that contains the DICOM files
         self.open_patient_directory_prompt = QLabel()
@@ -176,8 +159,35 @@ class UIImageFusionWindow(object):
         self.open_patient_directory_result_label.setObjectName(
             "OpenPatientDirectoryResultLabel")
         self.open_patient_directory_result_label.setAlignment(Qt.AlignLeft)
+
         self.open_patient_window_instance_vertical_box.addWidget(
             self.open_patient_directory_result_label)
+
+        # Fusion Mode Switch Selector (radio buttons) - place after the result label
+        fusion_mode_container = QtWidgets.QWidget()
+        fusion_mode_container_layout = QHBoxLayout()
+        fusion_mode_container_layout.setContentsMargins(10, 0, 0, 0)
+        fusion_mode_container_layout.setSpacing(10)
+        fusion_mode_container.setLayout(fusion_mode_container_layout)
+
+        fusion_mode_label = QLabel("Fusion Mode:")
+        fusion_mode_label.setObjectName("FusionModeLabel")
+        fusion_mode_container_layout.addWidget(fusion_mode_label)
+
+        self.fusion_mode_group = QButtonGroup()
+        self.manual_radio = QRadioButton("Manual Fusion")
+        self.manual_radio.setObjectName("FusionModeRadio")
+        self.auto_radio = QRadioButton("Auto Fusion")
+        self.auto_radio.setObjectName("FusionModeRadio")
+        self.fusion_mode_group.addButton(self.manual_radio)
+        self.fusion_mode_group.addButton(self.auto_radio)
+        self.manual_radio.setChecked(True)
+        self.manual_radio.setEnabled(False)
+        self.auto_radio.setEnabled(False)
+        fusion_mode_container_layout.addWidget(self.manual_radio)
+        fusion_mode_container_layout.addWidget(self.auto_radio)
+
+        self.open_patient_window_instance_vertical_box.addWidget(fusion_mode_container)
 
         # Create a horizontal box to hold the Cancel and Open button
         self.open_patient_window_patient_open_actions_horizontal_box = \

--- a/src/View/ImageFusion/ManualFusionLoader.py
+++ b/src/View/ImageFusion/ManualFusionLoader.py
@@ -1,0 +1,42 @@
+from PySide6 import QtCore
+import SimpleITK as sitk
+from src.Model.PatientDictContainer import PatientDictContainer
+
+class ManualFusionLoader(QtCore.QObject):
+    signal_loaded = QtCore.Signal(object)
+    signal_error = QtCore.Signal(object)
+
+    def __init__(self, selected_files, parent=None):
+        super().__init__(parent)
+        self.selected_files = selected_files
+
+    def load(self, interrupt_flag=None, progress_callback=None):
+        try:
+            # Optionally, emit progress if callback is provided
+            if progress_callback is not None:
+                progress_callback.emit(("Loading fixed image...", 10))
+            # Load fixed (base) and moving (overlay) images as SimpleITK
+            patient_dict_container = PatientDictContainer()
+            fixed_filepaths = []
+            for i in range(len(patient_dict_container.filepaths)):
+                try:
+                    fixed_filepaths.append(patient_dict_container.filepaths[i])
+                except KeyError:
+                    continue
+
+            moving_filepaths = self.selected_files
+
+            fixed_image = sitk.ReadImage(fixed_filepaths)
+            if progress_callback is not None:
+                progress_callback.emit(("Loading overlay image...", 50))
+            moving_image = sitk.ReadImage(moving_filepaths)
+
+            if progress_callback is not None:
+                progress_callback.emit(("Finished loading images", 100))
+
+            self.signal_loaded.emit((True, {
+                "fixed_image": fixed_image,
+                "moving_image": moving_image
+            }))
+        except Exception as e:
+            self.signal_error.emit((False, e))

--- a/src/View/ImageFusion/ROITransferOptionView.py
+++ b/src/View/ImageFusion/ROITransferOptionView.py
@@ -2,7 +2,6 @@ from PySide6 import QtWidgets
 from PySide6.QtWidgets import QPushButton
 
 from src.Controller.ROIOptionsController import ROITransferOption
-from src.View.ImageFusion.TranslateRotateMenu import TranslateRotateMenu
 
 class ROITransferOptionView(QtWidgets.QWidget):
     def __init__(self, fixed_dict_structure_modified_function,
@@ -18,7 +17,6 @@ class ROITransferOptionView(QtWidgets.QWidget):
 
         self.stacked_layout = QtWidgets.QStackedLayout()
         self.init_main_menu(fixed_dict_structure_modified_function, moving_dict_structure_modified_function)
-        self.init_translate_rotate_menu()
 
         self.setLayout(self.stacked_layout)
 
@@ -30,27 +28,14 @@ class ROITransferOptionView(QtWidgets.QWidget):
             ROITransferOption(fixed_dict_structure_modified_function,
                               moving_dict_structure_modified_function)
 
-        self.translate_rotate_button = QPushButton("Translate/Rotate")
         self.roi_transfer_option_button = QPushButton("Open ROI Transfer Options")
-
-        for btn in [self.translate_rotate_button, self.roi_transfer_option_button]:
-            btn.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
-            btn.setMinimumWidth(150)
-
-        self.translate_rotate_button.clicked.connect(self.show_translate_rotate_menu)
+        self.roi_transfer_option_button.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
+        self.roi_transfer_option_button.setMinimumWidth(150)
         self.roi_transfer_option_button.clicked.connect(self.open_roi_transfer_option)
 
-        layout.addWidget(self.translate_rotate_button)
         layout.addWidget(self.roi_transfer_option_button)
         self.main_menu_widget.setLayout(layout)
         self.stacked_layout.addWidget(self.main_menu_widget)
-
-    def init_translate_rotate_menu(self):
-        self.translate_rotate_menu = TranslateRotateMenu(self.show_main_menu)
-        self.stacked_layout.addWidget(self.translate_rotate_menu)
-
-    def show_translate_rotate_menu(self):
-        self.stacked_layout.setCurrentWidget(self.translate_rotate_menu)
 
     def show_main_menu(self):
         self.stacked_layout.setCurrentWidget(self.main_menu_widget)

--- a/src/View/ImageFusion/TranslateRotateMenu.py
+++ b/src/View/ImageFusion/TranslateRotateMenu.py
@@ -3,21 +3,23 @@ from PySide6.QtCore import Qt
 
 class TranslateRotateMenu(QtWidgets.QWidget):
     """
-    A menu for adjusting translation and rotation with sliders for each axis.
-    Displays sliders for 'LR', 'PA', and 'IS' for both translation and rotation.
+    A menu for adjusting translation, rotation, and opacity of the overlay image.
+    Displays sliders for 'LR', 'PA', and 'IS' for both translation and rotation,
+    and an opacity slider. Designed for a portrait layout.
     """
 
-    def __init__(self, back_callback):
+    def __init__(self, _back_callback=None):
         super().__init__()
         layout = QtWidgets.QVBoxLayout()
 
         # Translate section
-        translate_label = QtWidgets.QLabel("Translate")
-        layout.addWidget(translate_label)
+        layout.addSpacing(4)
+        layout.addWidget(QtWidgets.QLabel("Translate:"), alignment=Qt.AlignLeft)
         self.translate_sliders = []
         for axis in ['LR', 'PA', 'IS']:
             hbox = QtWidgets.QHBoxLayout()
             label = QtWidgets.QLabel(axis)
+            label.setFixedWidth(30)
             slider = QtWidgets.QSlider(Qt.Horizontal)
             slider.setMinimum(-100)
             slider.setMaximum(100)
@@ -28,12 +30,13 @@ class TranslateRotateMenu(QtWidgets.QWidget):
             self.translate_sliders.append(slider)
 
         # Rotate section
-        rotate_label = QtWidgets.QLabel("Rotate")
-        layout.addWidget(rotate_label)
+        layout.addSpacing(8)
+        layout.addWidget(QtWidgets.QLabel("Rotate:"), alignment=Qt.AlignLeft)
         self.rotate_sliders = []
         for axis in ['LR', 'PA', 'IS']:
             hbox = QtWidgets.QHBoxLayout()
             label = QtWidgets.QLabel(axis)
+            label.setFixedWidth(30)
             slider = QtWidgets.QSlider(Qt.Horizontal)
             slider.setMinimum(-180)
             slider.setMaximum(180)
@@ -43,9 +46,14 @@ class TranslateRotateMenu(QtWidgets.QWidget):
             layout.addLayout(hbox)
             self.rotate_sliders.append(slider)
 
-        # Back button
-        self.back_button = QtWidgets.QPushButton("Back")
-        self.back_button.clicked.connect(back_callback)
-        layout.addWidget(self.back_button)
+        # Opacity section
+        layout.addSpacing(8)
+        layout.addWidget(QtWidgets.QLabel("Overlay Opacity:"), alignment=Qt.AlignLeft)
+        self.opacity_slider = QtWidgets.QSlider(Qt.Horizontal)
+        self.opacity_slider.setMinimum(0)
+        self.opacity_slider.setMaximum(100)
+        self.opacity_slider.setValue(100)
+        layout.addWidget(self.opacity_slider)
 
+        layout.addStretch(1)
         self.setLayout(layout)

--- a/src/View/mainpage/MainPage.py
+++ b/src/View/mainpage/MainPage.py
@@ -438,13 +438,15 @@ class UIMainWindow:
             cut_line_color=QtGui.QColor(0, 255, 0))
         self.image_fusion_view_coronal = ImageFusionCoronalView(
             cut_line_color=QtGui.QColor(0, 0, 255))
+        self.image_fusion_roi_transfer_option_view = ROITransferOptionView(
+            self.structures_tab.fixed_container_structure_modified,
+            self.structures_tab.moving_container_structure_modified)
 
         # --- Fusion Options Tab with Translate/Rotate Menu ---
         from src.View.ImageFusion.TranslateRotateMenu import TranslateRotateMenu
         self.fusion_options_tab = TranslateRotateMenu(lambda: None)
         self.left_panel.addTab(self.fusion_options_tab, "Fusion Options")
         self.left_panel.setCurrentWidget(self.fusion_options_tab)
-
 
         # If manual fusion images are available, display them
         if hasattr(self, "fixed_image_sitk") and hasattr(self, "moving_image_sitk"):
@@ -486,7 +488,7 @@ class UIMainWindow:
             self.image_fusion_view_axial.image_display()
             self.image_fusion_view_coronal.image_display()
             self.image_fusion_view_sagittal.image_display()
-            
+
         # Rescale the size of the scenes inside the 3-slice views
         self.image_fusion_view_axial.zoom = INITIAL_FOUR_VIEW_ZOOM
         self.image_fusion_view_sagittal.zoom = INITIAL_FOUR_VIEW_ZOOM
@@ -507,7 +509,9 @@ class UIMainWindow:
         self.image_fusion_four_views_layout.addWidget(
             self.image_fusion_view_coronal, 1, 0)
 
-        # Remove ROITransferOptionView from fusion layout for manual fusion
+        self.image_fusion_four_views_layout.addWidget(
+            self.image_fusion_roi_transfer_option_view, 1, 1
+        )
 
         self.image_fusion_four_views.setLayout(
             self.image_fusion_four_views_layout)


### PR DESCRIPTION
Adding manual fusion tab to the auto fusion button

adding sliders (doesnt work yet)

adding images to 3 windows

## Summary by Sourcery

Introduce a manual image fusion workflow alongside the existing auto fusion, including a dedicated "Fusion Options" panel with translate, rotate, and opacity controls, a new loader for fixed and moving images, and overlay display in axial, coronal, and sagittal views.

New Features:
- Add manual fusion workflow with a "Fusion Options" tab featuring translate, rotate, and opacity sliders
- Introduce ManualFusionLoader to load fixed and moving DICOM images for manual fusion
- Add fusion mode selection radio buttons (Manual/Auto) in the Image Fusion window

Enhancements:
- Extend axial, coronal, and sagittal view renderers to support overlay images driven by slider values
- Automatically reload and populate the fusion tab with loaded images in TopLevelController
- Refactor ROITransferOptionView to remove its internal translate/rotate menu in favor of the new Fusion Options panel